### PR TITLE
Fix function name typo

### DIFF
--- a/patterns/dependency-injection/README.md
+++ b/patterns/dependency-injection/README.md
@@ -66,7 +66,7 @@ export default function inject(Component) {
 import inject from './inject.jsx';
 import Title from './Title.jsx';
 
-var EnhancedTitle = injector(Title);
+var EnhancedTitle = inject(Title);
 export default function Header() {
   return (
     <header>


### PR DESCRIPTION
Hey. It seems there's a typo in imported function name in DI section. I just fixed that. 😁 