### PR TITLE
Fix link to page about no autobinding

### DIFF
--- a/book/chapter-3/README.md
+++ b/book/chapter-3/README.md
@@ -83,7 +83,7 @@ class Switcher extends React.Component {
 };
 ```
 
-Facebook by the way [recommends](https://facebook.github.io/react/docs/reusable-components.html#no-autobinding) the same technique while dealing with functions that need the context of the same component.
+Facebook by the way [recommends](https://reactjs.org/docs/handling-events.html) the same technique while dealing with functions that need the context of the same component.
 
 The constructor is also a nice place for partially executing our handlers. For example, we have a form but want to handle every input in a single function.
 


### PR DESCRIPTION
While this book is being translated into Thai language, a contributor found that the link to https://facebook.github.io/react/docs/reusable-components.html#no-autobinding does not contain the target content: https://github.com/reactbkk/react-in-patterns-th/pull/15#issuecomment-395095808

The content has since been moved to another page, here: https://reactjs.org/docs/handling-events.html

This PR fixes it. 😄 