### PR TITLE
chapter 5 - grammar fix - remove extra word

### DIFF
--- a/book/chapter-5/README.md
+++ b/book/chapter-5/README.md
@@ -53,7 +53,7 @@ class App extends React.Component {
 };
 ```
 
-That `<input>` element above is a little bit useless because the user updates the value but our component has no idea about that. We then have to use [`Refs`](https://reactjs.org/docs/glossary.html#refs) to get an access to the actual element.
+That `<input>` element above is a little bit useless because the user updates the value but our component has no idea about that. We then have to use [`Refs`](https://reactjs.org/docs/glossary.html#refs) to get access to the actual element.
 
 ```js
 class App extends React.Component {


### PR DESCRIPTION
I do not think you need the word "an" in the sentence I am submitting a pull request for. 

So -> ...to get an access to the actual element.
Becomes -> ...to get access to the actual element.

