### PR TITLE
Fix typo

### DIFF
--- a/_book/chapter-10/index.html
+++ b/_book/chapter-10/index.html
@@ -409,7 +409,7 @@
                 <a href="./#using-reacts-context-prior-v-163">
             
                     
-                    Using React's context (prior v. 16.3)
+                    Using React's context (prior to v. 16.3)
             
                 </a>
             
@@ -675,7 +675,7 @@ export default function Header() {
 }
 </code></pre>
 <p>The <code>title</code> is hidden in a middle layer (higher-order component) where we pass it as a prop to the original <code>Title</code> component. That&apos;s all nice but it solves only half of the problem. Now we don&apos;t have to pass the <code>title</code> down the tree but how this data reaches the <code>inject.jsx</code> helper.</p>
-<h2 id="using-reacts-context-prior-v-163">Using React&apos;s context (prior v. 16.3)</h2>
+<h2 id="using-reacts-context-prior-v-163">Using React&apos;s context (prior to v. 16.3)</h2>
 <p><em>In v16.3 React&apos;s team introduced a new version of the context API and if you are going to use that version or above you&apos;d probably skip this section.</em></p>
 <p>React has the concept of <a href="https://facebook.github.io/react/docs/context.html" target="_blank"><em>context</em></a>. The <em>context</em> is something that every React component has access to. It&apos;s something like an <a href="https://github.com/krasimir/EventBus" target="_blank">event bus</a> but for data. A single <em>store</em> which we access from everywhere.</p>
 <pre><code class="lang-js"><span class="hljs-comment">// a place where we will define the context</span>
@@ -935,7 +935,7 @@ export default wire(
                 </a>
                 
                 
-                <a href="./#using-reacts-context-prior-v-163" class="navigation navigation-next " aria-label="Next page: Using React's context (prior v. 16.3)">
+                <a href="./#using-reacts-context-prior-v-163" class="navigation navigation-next " aria-label="Next page: Using React's context (prior to v. 16.3)">
                     <i class="fa fa-angle-right"></i>
                 </a>
                 
@@ -946,7 +946,7 @@ export default wire(
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            gitbook.page.hasChanged({"page":{"title":"Dependency injection","level":"4.1","depth":1,"next":{"title":"Using React's context (prior v. 16.3)","level":"4.1.1","depth":2,"anchor":"#using-reacts-context-prior-v-163","path":"chapter-10/README.md","ref":"chapter-10/README.md#using-reacts-context-prior-v-163","articles":[]},"previous":{"title":"Simple counter app using Redux","level":"3.3.2","depth":2,"anchor":"#simple-counter-app-using-redux","path":"chapter-09/README.md","ref":"chapter-09/README.md#simple-counter-app-using-redux","articles":[]},"dir":"ltr"},"config":{"plugins":[],"root":"./book","styles":{"website":"./styles/website.css","ebook":"./styles/ebook.css","pdf":"./styles/ebook.css"},"pluginsConfig":{"highlight":{},"search":{},"lunr":{"maxIndexSize":1000000,"ignoreSpecialCharacters":false},"sharing":{"facebook":true,"twitter":true,"google":false,"weibo":false,"instapaper":false,"vk":false,"all":["facebook","google","twitter","weibo","instapaper"]},"fontsettings":{"theme":"white","family":"sans","size":2},"theme-default":{"styles":{"website":"styles/website.css","pdf":"styles/pdf.css","epub":"styles/epub.css","mobi":"styles/mobi.css","ebook":"styles/ebook.css","print":"styles/print.css"},"showLevel":false}},"theme":"default","author":"Krasimir Tsonev","pdf":{"pageNumbers":true,"fontSize":12,"fontFamily":"Arial","paperSize":"a5","chapterMark":"pagebreak","pageBreaksBefore":"//*[@class='new-page']","margin":{"right":62,"left":62,"top":56,"bottom":56}},"structure":{"langs":"LANGS.md","readme":"README.md","glossary":"GLOSSARY.md","summary":"SUMMARY.md"},"variables":{},"title":"React in patterns","gitbook":"3.2.3","description":"A book about common design patterns used while developing with React."},"file":{"path":"chapter-10/README.md","mtime":"2018-10-17T19:02:30.000Z","type":"markdown"},"gitbook":{"version":"3.2.3","time":"2018-10-17T19:02:47.735Z"},"basePath":"..","book":{"language":""}});
+            gitbook.page.hasChanged({"page":{"title":"Dependency injection","level":"4.1","depth":1,"next":{"title":"Using React's context (prior to v. 16.3)","level":"4.1.1","depth":2,"anchor":"#using-reacts-context-prior-v-163","path":"chapter-10/README.md","ref":"chapter-10/README.md#using-reacts-context-prior-v-163","articles":[]},"previous":{"title":"Simple counter app using Redux","level":"3.3.2","depth":2,"anchor":"#simple-counter-app-using-redux","path":"chapter-09/README.md","ref":"chapter-09/README.md#simple-counter-app-using-redux","articles":[]},"dir":"ltr"},"config":{"plugins":[],"root":"./book","styles":{"website":"./styles/website.css","ebook":"./styles/ebook.css","pdf":"./styles/ebook.css"},"pluginsConfig":{"highlight":{},"search":{},"lunr":{"maxIndexSize":1000000,"ignoreSpecialCharacters":false},"sharing":{"facebook":true,"twitter":true,"google":false,"weibo":false,"instapaper":false,"vk":false,"all":["facebook","google","twitter","weibo","instapaper"]},"fontsettings":{"theme":"white","family":"sans","size":2},"theme-default":{"styles":{"website":"styles/website.css","pdf":"styles/pdf.css","epub":"styles/epub.css","mobi":"styles/mobi.css","ebook":"styles/ebook.css","print":"styles/print.css"},"showLevel":false}},"theme":"default","author":"Krasimir Tsonev","pdf":{"pageNumbers":true,"fontSize":12,"fontFamily":"Arial","paperSize":"a5","chapterMark":"pagebreak","pageBreaksBefore":"//*[@class='new-page']","margin":{"right":62,"left":62,"top":56,"bottom":56}},"structure":{"langs":"LANGS.md","readme":"README.md","glossary":"GLOSSARY.md","summary":"SUMMARY.md"},"variables":{},"title":"React in patterns","gitbook":"3.2.3","description":"A book about common design patterns used while developing with React."},"file":{"path":"chapter-10/README.md","mtime":"2018-10-17T19:02:30.000Z","type":"markdown"},"gitbook":{"version":"3.2.3","time":"2018-10-17T19:02:47.735Z"},"basePath":"..","book":{"language":""}});
         });
     </script>
 </div>


### PR DESCRIPTION
Fix typo as mentioned in issue #72

There are many ways to fix this, but most of them would involve checking the whole book for consistency, so the most simple solution is to change "prior" to "prior to".

Please note: I also changed this in the `gitbook.page.hasChanged` function call at the end. Perhaps that change is not necessary.